### PR TITLE
Update .gitattributes to fix "cwSproj" and add EXP TRN INI, plus RegEx

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,10 +3,16 @@
 
 # Declare files that will always have CRLF line endings on checkout.
 *.sln text eol=crlf
-*.cwsproj eol=crlf
+*.cwproj text eol=crlf
 *.clw text eol=crlf
 *.inc text eol=crlf
+*.[Ii][Nn][Cc] text eol=crlf
+*.trn text eol=crlf
+*.exp text eol=crlf
+*.[Ii][Nn][Ii] text eol=crlf
 
 # Denote all files that are truly binary and should not be modified.
 *.bmp binary
+*.[Bb][Mm][Pp] binary
 *.ico binary
+*.[Ii][Cc][Oo] binary


### PR DESCRIPTION
Correct "cwSproj" to be "cwproj" without "s", plus add "text" attribute. 
Added .exp and .trn that are Text files in Repo
I think file names are case sensitive? 
There are .INC in upper case so added RegEx: *.[Ii][Nn][Cc], 
Added .INI files as RegEx: *.[Ii][Nn][Ii] text eol=crlf
ICO and BMP are upper in repo so would be best as RegEx: *.[Bb][Mm][Pp] and *.[Ii][Cc][Oo]