### PR TITLE
Fix Blank Error messages in Error Class

### DIFF
--- a/Cnveng.clw
+++ b/Cnveng.clw
@@ -118,6 +118,7 @@ EngineStartup       PROCEDURE()
        ! DB.Init('Convertor')
         
         LocalError.Init(LocalErrorStatus)
+        LocalError.AddErrors(LocalErrors)
         IF GlobalErrors &= NULL
             GlobalErrors &= LocalError
         END

--- a/Cnveng.trn
+++ b/Cnveng.trn
@@ -44,7 +44,7 @@ Number          USHORT(17)
                 USHORT(Msg:BadTXA)
                 BYTE(Level:Notify)
                 PSTRING('Invaild TXA File')
-                PSTRING('The input TXA file is invalid or has been damaged|')
+                PSTRING('The input TXA file is not [APPLICATION] type, is invalid or has been damaged|')  !Note: Not supported are Single [PROCEDURE] and [MODULE] TXA ... currently
                 USHORT(Msg:OutTXAWriteErr)
                 BYTE(Level:Notify)
                 PSTRING('TXA Write Error')


### PR DESCRIPTION
All Error Class messages were showing blank text because the LocalErrors were not loaded from the CnvEng.TRN. Russ changed from GlobalErrors class to have a LocalError class but left out the line  LocalError.AddErrors(LocalErrors)

I also made clear the TXA must be [Application]
I would like it to support [Procedure] and [Module] which I think I did it previously.