### PR TITLE
Change VIRTUAL to DERIVED in derived classes

### DIFF
--- a/CNVENG.INC
+++ b/CNVENG.INC
@@ -174,7 +174,7 @@ Width                   SHORT
 Height                  SHORT
                       END
 Construct             PROCEDURE(),PRIVATE
-Destruct              PROCEDURE(),PRIVATE
+Destruct              PROCEDURE(),PRIVATE,VIRTUAL
 AfterConversion       PROCEDURE(),VIRTUAL               !Called in Rule priority sequence after full conversion
 BeforeConversion      PROCEDURE(),VIRTUAL               !Called in Rule priority sequence before any conversion
 CurrentAddition       PROCEDURE(),STRING
@@ -235,7 +235,7 @@ InTXAClass          CLASS(FileManager),TYPE,MODULE('CNVENG.CLW')
 FileSize              LONG,PRIVATE
 Line                  &STRING,PRIVATE
 Init                  PROCEDURE(ErrorClass ErrMgr),PRIVATE
-Kill                  PROCEDURE(),VIRTUAL,PRIVATE
+Kill                  PROCEDURE(),DERIVED,PRIVATE
 Next                  PROCEDURE(),BYTE,PROC,DERIVED
 ReadFile              PROCEDURE(ApplicationClass TXAQMgr,ProgressManagerClass Progress),BYTE,PRIVATE
                     END
@@ -243,7 +243,7 @@ ReadFile              PROCEDURE(ApplicationClass TXAQMgr,ProgressManagerClass Pr
 OutTXAClass         CLASS(FileManager),TYPE,MODULE('CNVENG.CLW')
 Line                  &STRING,PRIVATE
 Init                  PROCEDURE(ErrorClass ErrMgr),PRIVATE
-Kill                  PROCEDURE(),VIRTUAL,PRIVATE
+Kill                  PROCEDURE(),DERIVED,PRIVATE
 Update                PROCEDURE(),BYTE,PROC,DERIVED
 WriteFile             PROCEDURE(ApplicationClass TXAQMgr,ProgressManagerClass Progress),BYTE,PRIVATE
                     END

--- a/Cnvbeta.clw
+++ b/Cnvbeta.clw
@@ -13,17 +13,17 @@ OwnerName       EQUATE('Clarion 4 Betas')
 
 ConvertC4B1     CLASS(RuleClass)
 Construct         PROCEDURE
-TakeSection       FUNCTION(SectionClass SectionMgr,InfoTextClass Info,STRING SectionHeader),BYTE,VIRTUAL
+TakeSection       FUNCTION(SectionClass SectionMgr,InfoTextClass Info,STRING SectionHeader),BYTE,DERIVED
                 END
 
 RemoveSymbols   CLASS(RuleClass)
 Construct         PROCEDURE
-TakeSection       FUNCTION(SectionClass SectionMgr,InfoTextClass Info,STRING SectionHeader),BYTE,VIRTUAL
+TakeSection       FUNCTION(SectionClass SectionMgr,InfoTextClass Info,STRING SectionHeader),BYTE,DERIVED
                 END
 
 UpdateSymbols   CLASS(RuleClass)
 Construct         PROCEDURE
-TakeSection       FUNCTION(SectionClass SectionMgr,InfoTextClass Info,STRING SectionHeader),BYTE,VIRTUAL
+TakeSection       FUNCTION(SectionClass SectionMgr,InfoTextClass Info,STRING SectionHeader),BYTE,DERIVED
                 END
 
 
@@ -103,7 +103,7 @@ j USHORT,AUTO
     SectionMgr.GetLine(i,cLine)
     IF SELF.PreFilterLine(cLine,'.Q.') AND SELF.SaveComment(cLine)
       LOOP j=1 TO LEN(cLine)
-        IF cLine[j]='_' THEN cLine[j]=':'.
+        IF cLine[j]='_' THEN cLine[j]=':'.    !Carl FYI: It appears C4 Beta used "_" in browse fields, now uses ":"
       END
       IF SectionMgr.LineChanged(i,cLine)
         SELF.RestoreComment(cLine)

--- a/Cnveng.clw
+++ b/Cnveng.clw
@@ -6,9 +6,10 @@
 !-------------------------------------------------------------------------------------------------
 ! History 
 !-------------------------------------------------------------------------------------------------
-! 2022-11-07  C. Barnes     Change Help HLP to CHM. All HLP('~xxx') added '.htm' to open CHM topic.
-! 2022-11-08  C. Barnes     Window Cosmetics - Change font to Microsoft Sans Serif - adjust controls
-! 2022-11-14  C. Barnes     Rules were limited to 18 per DLL and 32 total, now 128 for both although Window will need to be resized by user at runtime
+! 2022-11-07  Carl B.       Change Help HLP to CHM. All HLP('~xxx') added '.htm' to open CHM topic.
+! 2022-11-08  Carl B.       Window Cosmetics - Change font to Microsoft Sans Serif - adjust controls
+! 2022-11-14  Carl B.       Rules were limited to 18 per DLL and 32 total, now 128 for both although Window will need to be resized by user at runtime
+! 2022-11-16  Carl B.       Change VIRTUAL to DERIVED for inherited/derived classes so compiler checks signature matches. Destructors added VIRTUAL
 !-------------------------------------------------------------------------------------------------
 
                     PROGRAM
@@ -236,11 +237,11 @@ Resizer                 WindowResizeClass
 
 ThisWindow              CLASS(WindowManager)
 ControlsCreated             BYTE,PRIVATE
-Init                        PROCEDURE(),BYTE,VIRTUAL
-Kill                        PROCEDURE(),BYTE,VIRTUAL,PROC
-TakeAccepted                PROCEDURE(),VIRTUAL,BYTE,PROC
-TakeCloseEvent              PROCEDURE(),VIRTUAL,BYTE,PROC
-TakeWindowEvent             PROCEDURE(),VIRTUAL,BYTE,PROC
+Init                        PROCEDURE(),BYTE,DERIVED
+Kill                        PROCEDURE(),BYTE,DERIVED,PROC
+TakeAccepted                PROCEDURE(),DERIVED,BYTE,PROC
+TakeCloseEvent              PROCEDURE(),DERIVED,BYTE,PROC
+TakeWindowEvent             PROCEDURE(),DERIVED,BYTE,PROC
                         END
 
     CODE
@@ -933,12 +934,12 @@ Popup                   PopupClass
 Resizer                 WindowResizeClass
 RVal                    BYTE(Action:Cancel)
 ThisWindow              CLASS(WindowManager)
-Ask                         PROCEDURE,VIRTUAL
-Init                        PROCEDURE,BYTE,VIRTUAL
-Kill                        PROCEDURE,BYTE,VIRTUAL,PROC
-TakeEvent                   PROCEDURE,VIRTUAL,BYTE
-TakeFieldEvent              PROCEDURE,VIRTUAL,BYTE
-TakeAccepted                PROCEDURE,VIRTUAL,BYTE,PROC
+Ask                         PROCEDURE,DERIVED
+Init                        PROCEDURE,BYTE,DERIVED
+Kill                        PROCEDURE,BYTE,DERIVED,PROC
+TakeEvent                   PROCEDURE,DERIVED,BYTE
+TakeFieldEvent              PROCEDURE,DERIVED,BYTE
+TakeAccepted                PROCEDURE,DERIVED,BYTE,PROC
                         END
 
     CODE

--- a/Cnvrules.clw
+++ b/Cnvrules.clw
@@ -4,6 +4,12 @@
 !Open sourced by kind permission of Robert Zaunere
 !In Memory of Russell Eggen
 
+!-------------------------------------------------------------------------------------------------
+! History 
+!-------------------------------------------------------------------------------------------------
+! 2022-11-16  Carl B.       Change VIRTUAL to DERIVED for inherited/derived classes so compiler checks signature matches. Destructors added VIRTUAL
+!
+!-------------------------------------------------------------------------------------------------
 
                     MEMBER()
 
@@ -35,98 +41,98 @@ Referenced            BYTE
 
 AscViewer           CLASS(RuleClass)
 Construct             PROCEDURE()
-TakeSection           PROCEDURE(SectionClass SectionMgr,InfoTextClass Info,STRING SectionHeader),BYTE,VIRTUAL
+TakeSection           PROCEDURE(SectionClass SectionMgr,InfoTextClass Info,STRING SectionHeader),BYTE,DERIVED
                     END
 
 BadLocals           CLASS(RuleClass)
 State                 BYTE,PRIVATE
 Construct             PROCEDURE()
-TakeSection           PROCEDURE(SectionClass SectionMgr,InfoTextClass Info,STRING SectionHeader),BYTE,VIRTUAL
+TakeSection           PROCEDURE(SectionClass SectionMgr,InfoTextClass Info,STRING SectionHeader),BYTE,DERIVED
                     END
 
 BrowseFormula       CLASS(RuleClass)
 Construct             PROCEDURE()
-TakeSection           PROCEDURE(SectionClass SectionMgr,InfoTextClass Info,STRING SectionHeader),BYTE,VIRTUAL
+TakeSection           PROCEDURE(SectionClass SectionMgr,InfoTextClass Info,STRING SectionHeader),BYTE,DERIVED
                     END
 
 BrwRoutine          CLASS(RuleClass)
 Construct             PROCEDURE()
-TakeSection           PROCEDURE(SectionClass SectionMgr,InfoTextClass Info,STRING SectionHeader),BYTE,VIRTUAL
+TakeSection           PROCEDURE(SectionClass SectionMgr,InfoTextClass Info,STRING SectionHeader),BYTE,DERIVED
                     END
 
 BrwQueue            CLASS(RuleClass)
 Construct             PROCEDURE()
-TakeSection           PROCEDURE(SectionClass SectionMgr,InfoTextClass Info,STRING SectionHeader),BYTE,VIRTUAL
+TakeSection           PROCEDURE(SectionClass SectionMgr,InfoTextClass Info,STRING SectionHeader),BYTE,DERIVED
                     END
 
 BrwFeq              CLASS(RuleClass)
 Construct             PROCEDURE()
-TakeSection           PROCEDURE(SectionClass SectionMgr,InfoTextClass Info,STRING SectionHeader),BYTE,VIRTUAL
+TakeSection           PROCEDURE(SectionClass SectionMgr,InfoTextClass Info,STRING SectionHeader),BYTE,DERIVED
 VirtualFeqCheck       PROCEDURE(SectionClass SectionMgr,InfoTextClass Info,STRING FeqLabel,STRING Replacement,*CSTRING cLine,LONG LineNo)
                     END
 
 Hints               CLASS(RuleClass)
 Construct             PROCEDURE()
-TakeSection           PROCEDURE(SectionClass SectionMgr,InfoTextClass Info,STRING SectionHeader),BYTE,VIRTUAL
+TakeSection           PROCEDURE(SectionClass SectionMgr,InfoTextClass Info,STRING SectionHeader),BYTE,DERIVED
                     END
 
 UnTerminatedOmits   CLASS(RuleClass)
 Construct             PROCEDURE()
-TakeSection           PROCEDURE(SectionClass SectionMgr,InfoTextClass Info,STRING SectionHeader),BYTE,VIRTUAL
+TakeSection           PROCEDURE(SectionClass SectionMgr,InfoTextClass Info,STRING SectionHeader),BYTE,DERIVED
 TerminatorFound       PROCEDURE(SectionClass SectionMgr,STRING LookFor,LONG StartLine),BYTE
                     END
 
 StdFunc             CLASS(RuleClass)
 Construct             PROCEDURE()
-TakeSection           PROCEDURE(SectionClass SectionMgr,InfoTextClass Info,STRING SectionHeader),BYTE,VIRTUAL
+TakeSection           PROCEDURE(SectionClass SectionMgr,InfoTextClass Info,STRING SectionHeader),BYTE,DERIVED
                     END
 
 TBarEqu             CLASS(RuleClass)
 Construct             PROCEDURE()
-TakeSection           PROCEDURE(SectionClass SectionMgr,InfoTextClass Info,STRING SectionHeader),BYTE,VIRTUAL
+TakeSection           PROCEDURE(SectionClass SectionMgr,InfoTextClass Info,STRING SectionHeader),BYTE,DERIVED
                     END
 
 WinRoutine          CLASS(RuleClass)
 Construct             PROCEDURE()
-TakeSection           PROCEDURE(SectionClass SectionMgr,InfoTextClass Info,STRING SectionHeader),BYTE,VIRTUAL
+TakeSection           PROCEDURE(SectionClass SectionMgr,InfoTextClass Info,STRING SectionHeader),BYTE,DERIVED
                     END
 
 RepRoutine          CLASS(RuleClass)
 Construct             PROCEDURE()
-TakeSection           PROCEDURE(SectionClass SectionMgr,InfoTextClass Info,STRING SectionHeader),BYTE,VIRTUAL
+TakeSection           PROCEDURE(SectionClass SectionMgr,InfoTextClass Info,STRING SectionHeader),BYTE,DERIVED
                     END
 
 ProcRoutine         CLASS(RuleClass)
 Construct             PROCEDURE()
-TakeSection           PROCEDURE(SectionClass SectionMgr,InfoTextClass Info,STRING SectionHeader),BYTE,VIRTUAL
+TakeSection           PROCEDURE(SectionClass SectionMgr,InfoTextClass Info,STRING SectionHeader),BYTE,DERIVED
                     END
 
 FileAccess          CLASS(RuleClass)
 lDev                  SHORT
 
 Construct             PROCEDURE()
-TakeSection           PROCEDURE(SectionClass SectionMgr,InfoTextClass Info,STRING SectionHeader),BYTE,VIRTUAL
+TakeSection           PROCEDURE(SectionClass SectionMgr,InfoTextClass Info,STRING SectionHeader),BYTE,DERIVED
 ReplaceFcall          PROCEDURE(*CSTRING cLine,LONG i,STRING Func,STRING NewFunc,SectionClass SectionMgr, InfoTextClass Info)
                     END
 
 ChangeTplChain      CLASS(RuleCLass)
 Construct             PROCEDURE()
-TakeSection           PROCEDURE(SectionClass SectionMgr,InfoTextClass Info,STRING SectionHeader),BYTE,VIRTUAL
+TakeSection           PROCEDURE(SectionClass SectionMgr,InfoTextClass Info,STRING SectionHeader),BYTE,DERIVED
                     END
 
 UnLinkedProc        CLASS(RuleClass)
 ThisProcedure         CSTRING(64),PRIVATE
 UnLinked              &UnLinkedQ,PRIVATE
 
-BeforeConversion      PROCEDURE,VIRTUAL
+BeforeConversion      PROCEDURE,DERIVED
 Construct             PROCEDURE()
-Destruct              PROCEDURE()
-TakeSection           PROCEDURE(SectionClass SectionMgr,InfoTextClass Info,STRING SectionHeader),BYTE,VIRTUAL
+Destruct              PROCEDURE(),VIRTUAL
+TakeSection           PROCEDURE(SectionClass SectionMgr,InfoTextClass Info,STRING SectionHeader),BYTE,DERIVED
                     END
 
 RptDetailUse        CLASS(RuleClass)
 Construct             PROCEDURE()
-TakeSection           PROCEDURE(SectionClass SectionMgr,InfoTextClass Info,STRING SectionHeader),BYTE,VIRTUAL
+TakeSection           PROCEDURE(SectionClass SectionMgr,InfoTextClass Info,STRING SectionHeader),BYTE,DERIVED
                     END
 
 InitializeDLL       PROCEDURE()


### PR DESCRIPTION
Original code was from C4 that did not have DERIVED so all were VIRTUAL. With DERIVED the compiler will check there is a matching VIRTUAL method or will error.